### PR TITLE
test: add clockwise dealer rotation property tests

### DIFF
--- a/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerPreservationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerPreservationPropertyTest.java
@@ -1,0 +1,229 @@
+package com.nekocatgato.engine;
+
+// Bugfix: clockwise-dealer-rotation, Property 2: Preservation
+
+import com.nekocatgato.model.*;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Property 2: Preservation - Blind posting, elimination, heads-up, and reset unchanged
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4
+ */
+class ClockwiseDealerPreservationPropertyTest {
+
+    static class StubPlayer extends Player {
+        StubPlayer(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public Action decideAction(GameState state, int callAmount) {
+            return callAmount == 0 ? Action.CHECK : Action.CALL;
+        }
+    }
+
+    static class AutoHumanPlayer extends HumanPlayer {
+        AutoHumanPlayer(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public CompletableFuture<ActionResult> decideActionAsync(GameState state, int callAmount) {
+            CompletableFuture<ActionResult> future = super.decideActionAsync(state, callAmount);
+            submitAction(Player.Action.CALL, 0);
+            return future;
+        }
+    }
+
+    static class NoOpListener implements GameEventListener {
+        @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
+        @Override public void onPlayerTurn(Player player, int callAmount) {}
+        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onRoundComplete(GameState state) {}
+        @Override public void onPlayerEliminated(Player player) {}
+        @Override public void onGameOver(Player winner) {}
+        @Override public void onError(Exception e) {}
+    }
+
+    private static void setField(GameController gc, String fieldName, Object value) throws Exception {
+        Field field = GameController.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(gc, value);
+    }
+
+    /**
+     * Property: For all player counts (2-9) and dealer positions,
+     * small blind is deducted from (dealer+1) and big blind from (dealer+2).
+     */
+    @Property(tries = 100)
+    void blindsPostedAtCorrectPositions(
+            @ForAll @IntRange(min = 2, max = 9) int playerCount,
+            @ForAll @IntRange(min = 500, max = 5000) int initialChips) throws Exception {
+
+        List<Player> players = new ArrayList<>();
+        players.add(new StubPlayer("You", initialChips));
+        for (int i = 1; i < playerCount; i++) {
+            players.add(new StubPlayer("AI" + i, initialChips));
+        }
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // After startGame, dealer is at 0, blinds posted
+        int dealerIdx = gc.getDealerButtonIndex();
+        int sbIdx = (dealerIdx + 1) % playerCount;
+        int bbIdx = (dealerIdx + 2) % playerCount;
+
+        Player sbPlayer = gc.getPlayers().get(sbIdx);
+        Player bbPlayer = gc.getPlayers().get(bbIdx);
+
+        int expectedSB = Math.min(GameController.SMALL_BLIND, initialChips);
+        int expectedBB = Math.min(GameController.BIG_BLIND, initialChips);
+
+        assert sbPlayer.getCurrentBet() == expectedSB :
+                "SB player at index " + sbIdx + " should have bet " + expectedSB +
+                " but has " + sbPlayer.getCurrentBet();
+
+        assert bbPlayer.getCurrentBet() == expectedBB :
+                "BB player at index " + bbIdx + " should have bet " + expectedBB +
+                " but has " + bbPlayer.getCurrentBet();
+
+        // Total pot should equal SB + BB
+        int expectedPot = expectedSB + expectedBB;
+        assert gc.getState().getPot() == expectedPot :
+                "Pot should be " + expectedPot + " but is " + gc.getState().getPot();
+    }
+
+    /**
+     * Property: For 2-player games, dealer posts SB and other player posts BB.
+     */
+    @Property(tries = 50)
+    void headsUpBlindsCorrect(
+            @ForAll @IntRange(min = 500, max = 5000) int initialChips) throws Exception {
+
+        List<Player> players = List.of(
+            new StubPlayer("You", initialChips),
+            new StubPlayer("AI1", initialChips)
+        );
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // Dealer is at 0, SB at (0+1)%2=1, BB at (0+2)%2=0
+        // In heads-up, dealer+1 is the other player (SB), dealer+2 wraps to dealer (BB)
+        int dealerIdx = gc.getDealerButtonIndex();
+        int sbIdx = (dealerIdx + 1) % 2;
+        int bbIdx = (dealerIdx + 2) % 2;
+
+        Player sbPlayer = gc.getPlayers().get(sbIdx);
+        Player bbPlayer = gc.getPlayers().get(bbIdx);
+
+        int expectedSB = Math.min(GameController.SMALL_BLIND, initialChips);
+        int expectedBB = Math.min(GameController.BIG_BLIND, initialChips);
+
+        assert sbPlayer.getCurrentBet() == expectedSB :
+                "Heads-up SB should be " + expectedSB + " but is " + sbPlayer.getCurrentBet();
+        assert bbPlayer.getCurrentBet() == expectedBB :
+                "Heads-up BB should be " + expectedBB + " but is " + bbPlayer.getCurrentBet();
+    }
+
+    /**
+     * Property: After elimination, dealer index is valid in the shortened list.
+     */
+    @Property(tries = 100)
+    void eliminationPreservesDealerValidity(
+            @ForAll @IntRange(min = 3, max = 9) int playerCount,
+            @ForAll @IntRange(min = 0, max = 7) int eliminateIndex,
+            @ForAll Random random) throws Exception {
+
+        if (eliminateIndex >= playerCount) return; // skip invalid combos
+
+        int chips = 1000;
+        List<Player> players = new ArrayList<>();
+        players.add(new StubPlayer("You", chips));
+        for (int i = 1; i < playerCount; i++) {
+            players.add(new StubPlayer("AI" + i, chips));
+        }
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // Set a random dealer position
+        int dealerPos = random.nextInt(playerCount);
+        setField(gc, "dealerButtonIndex", dealerPos);
+
+        // Eliminate one player by zeroing their chips
+        gc.getPlayers().get(eliminateIndex).setChips(0);
+        List<Integer> eliminated = gc.eliminateBrokePlayers();
+        gc.adjustDealerIndexAfterElimination(eliminated);
+
+        int newDealerIdx = gc.getDealerButtonIndex();
+        int newSize = gc.getPlayers().size();
+
+        // Dealer index must be valid: either -1 (will be fixed by nextRound) or in [0, newSize)
+        assert newDealerIdx >= -1 && newDealerIdx < newSize :
+                "After eliminating index " + eliminateIndex + " from " + playerCount +
+                " players (dealer was " + dealerPos + "), dealer index " + newDealerIdx +
+                " is out of range [−1, " + (newSize - 1) + "]";
+    }
+
+    /**
+     * Property: resetAndRestart restores all players with initial chips
+     * and resets dealer to 0 (after nextRound inside reset).
+     */
+    @Property(tries = 50)
+    void resetRestoresInitialState(
+            @ForAll @IntRange(min = 2, max = 6) int playerCount,
+            @ForAll @IntRange(min = 500, max = 5000) int initialChips) throws Exception {
+
+        AutoHumanPlayer human = new AutoHumanPlayer("Human", initialChips);
+        List<Player> players = new ArrayList<>();
+        players.add(human);
+        for (int i = 1; i < playerCount; i++) {
+            players.add(new StubPlayer("AI" + i, initialChips));
+        }
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // Simulate game over
+        setField(gc, "gameOver", true);
+        setField(gc, "gameWinner", gc.getPlayers().get(0));
+
+        gc.resetAndRestart();
+
+        // All players restored
+        assert gc.getPlayers().size() == playerCount :
+                "Expected " + playerCount + " players after reset, got " + gc.getPlayers().size();
+
+        // Game not over
+        assert !gc.isGameOver() : "Game should not be over after reset";
+        assert gc.getGameWinner() == null : "Winner should be null after reset";
+
+        // Dealer at 0 (reset sets to -1, nextRound advances to 0)
+        assert gc.getDealerButtonIndex() == 0 :
+                "Dealer should be 0 after reset, got " + gc.getDealerButtonIndex();
+
+        // Total chips preserved (accounting for blinds in pot)
+        int totalChips = 0;
+        for (Player p : gc.getPlayers()) {
+            totalChips += p.getChips();
+        }
+        totalChips += gc.getState().getPot();
+        assert totalChips == playerCount * initialChips :
+                "Total chips should be " + (playerCount * initialChips) + " but got " + totalChips;
+
+        // Clean up async executor
+        gc.signalNextRound();
+    }
+}

--- a/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerRotationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerRotationPropertyTest.java
@@ -1,0 +1,121 @@
+package com.nekocatgato.engine;
+
+// Bugfix: clockwise-dealer-rotation, Property 1: Dealer rotates clockwise
+
+import com.nekocatgato.model.*;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.*;
+
+/**
+ * Property 1: Dealer rotates in clockwise seating order
+ *
+ * For a 4-player game where the player list is ordered clockwise
+ * (You, Bob, Alice, Charlie), the dealer button SHALL advance through
+ * indices 0 → 1 → 2 → 3 → 0, which corresponds to the clockwise
+ * seating order (bottom → left → top → right).
+ *
+ * Validates: Requirements 2.1, 2.3
+ */
+class ClockwiseDealerRotationPropertyTest {
+
+    static class StubPlayer extends Player {
+        StubPlayer(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public Action decideAction(GameState state, int callAmount) {
+            return callAmount == 0 ? Action.CHECK : Action.CALL;
+        }
+    }
+
+    static class NoOpListener implements GameEventListener {
+        @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
+        @Override public void onPlayerTurn(Player player, int callAmount) {}
+        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onRoundComplete(GameState state) {}
+        @Override public void onPlayerEliminated(Player player) {}
+        @Override public void onGameOver(Player winner) {}
+        @Override public void onError(Exception e) {}
+    }
+
+    /**
+     * Verify that for any starting dealer position in a 4-player game,
+     * advancing the dealer produces the next player in list order,
+     * which (with the fix) IS the clockwise seating order.
+     */
+    @Property(tries = 50)
+    void dealerAdvancesClockwiseForFourPlayers(
+            @ForAll @IntRange(min = 0, max = 3) int startingDealer) throws Exception {
+
+        int chips = 100_000;
+        List<Player> players = List.of(
+            new StubPlayer("You", chips),
+            new StubPlayer("Bob", chips),
+            new StubPlayer("Alice", chips),
+            new StubPlayer("Charlie", chips)
+        );
+
+        // Expected clockwise order: You(0) → Bob(1) → Alice(2) → Charlie(3)
+        String[] expectedOrder = {"You", "Bob", "Alice", "Charlie"};
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // Advance dealer to the starting position
+        // startGame calls nextRound which sets dealer to 0
+        // We need to advance (startingDealer) more times
+        for (int i = 0; i < startingDealer; i++) {
+            gc.nextRound();
+        }
+
+        assert gc.getDealerButtonIndex() == startingDealer :
+                "Setup: dealer should be at " + startingDealer;
+
+        // Advance one more round and verify next dealer is clockwise
+        gc.nextRound();
+        int nextDealer = gc.getDealerButtonIndex();
+        int expectedNext = (startingDealer + 1) % 4;
+
+        assert nextDealer == expectedNext :
+                "From dealer " + expectedOrder[startingDealer] + " (index " + startingDealer +
+                "), expected next dealer " + expectedOrder[expectedNext] + " (index " + expectedNext +
+                ") but got index " + nextDealer;
+    }
+
+    /**
+     * Verify a full cycle of dealer rotation for N players (2-9)
+     * always advances sequentially through list indices.
+     */
+    @Property(tries = 50)
+    void fullCycleRotatesClockwise(
+            @ForAll @IntRange(min = 2, max = 9) int playerCount) throws Exception {
+
+        int chips = 100_000;
+        List<Player> players = new ArrayList<>();
+        players.add(new StubPlayer("You", chips));
+        for (int i = 1; i < playerCount; i++) {
+            players.add(new StubPlayer("AI" + i, chips));
+        }
+
+        GameController gc = new GameController();
+        gc.setGameEventListener(new NoOpListener());
+        gc.startGame(players);
+
+        // After startGame + nextRound, dealer is at 0
+        assert gc.getDealerButtonIndex() == 0;
+
+        // Advance through a full cycle
+        for (int round = 1; round <= playerCount; round++) {
+            gc.nextRound();
+            int expected = round % playerCount;
+            int actual = gc.getDealerButtonIndex();
+            assert actual == expected :
+                    "Round " + round + " with " + playerCount + " players: " +
+                    "expected dealer " + expected + " but got " + actual;
+        }
+    }
+}

--- a/app/src/test/java/com/nekocatgato/ui/ShowdownCardRevealPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/ui/ShowdownCardRevealPropertyTest.java
@@ -1,0 +1,108 @@
+package com.nekocatgato.ui;
+
+// Bugfix: showdown-card-reveal, Properties 1 & 2
+
+import com.nekocatgato.engine.HandEvaluator;
+import net.jqwik.api.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Property tests for the showdown card reveal bugfix.
+ *
+ * Property 1 (Bug Condition): formatHandRank produces correct display strings
+ * Property 2 (Preservation): formatHandRank covers all HandRank enum values
+ *
+ * Note: Card persistence and hand rank label visibility tests require JavaFX
+ * and are not included here. These tests cover the testable logic extracted
+ * from GameTableView.
+ *
+ * Validates: Requirements 2.3, 2.4, 3.1, 3.2, 3.3, 3.4
+ */
+class ShowdownCardRevealPropertyTest {
+
+    /**
+     * Property: For all HandRank enum values, formatHandRank produces
+     * a non-empty string with no underscores and proper title case.
+     */
+    @Property(tries = 50)
+    void formatHandRankProducesValidDisplayString(
+            @ForAll("handRanks") HandEvaluator.HandRank rank) {
+
+        String result = GameTableView.formatHandRank(rank);
+
+        assertNotNull(result, "formatHandRank should not return null");
+        assertFalse(result.isEmpty(), "formatHandRank should not return empty string");
+        assertFalse(result.contains("_"), "Display string should not contain underscores: " + result);
+
+        // Each word should start with uppercase
+        for (String word : result.split(" ")) {
+            assertTrue(Character.isUpperCase(word.charAt(0)),
+                    "Each word should start with uppercase: '" + word + "' in '" + result + "'");
+            // Rest of word should be lowercase
+            if (word.length() > 1) {
+                String rest = word.substring(1);
+                assertEquals(rest.toLowerCase(), rest,
+                        "Rest of word should be lowercase: '" + word + "' in '" + result + "'");
+            }
+        }
+    }
+
+    @Provide
+    Arbitrary<HandEvaluator.HandRank> handRanks() {
+        return Arbitraries.of(HandEvaluator.HandRank.values());
+    }
+
+    // ── Unit tests for specific HandRank values ──
+
+    @Test
+    void formatHighCard() {
+        assertEquals("High Card", GameTableView.formatHandRank(HandEvaluator.HandRank.HIGH_CARD));
+    }
+
+    @Test
+    void formatOnePair() {
+        assertEquals("One Pair", GameTableView.formatHandRank(HandEvaluator.HandRank.ONE_PAIR));
+    }
+
+    @Test
+    void formatTwoPair() {
+        assertEquals("Two Pair", GameTableView.formatHandRank(HandEvaluator.HandRank.TWO_PAIR));
+    }
+
+    @Test
+    void formatThreeOfAKind() {
+        assertEquals("Three Of A Kind", GameTableView.formatHandRank(HandEvaluator.HandRank.THREE_OF_A_KIND));
+    }
+
+    @Test
+    void formatStraight() {
+        assertEquals("Straight", GameTableView.formatHandRank(HandEvaluator.HandRank.STRAIGHT));
+    }
+
+    @Test
+    void formatFlush() {
+        assertEquals("Flush", GameTableView.formatHandRank(HandEvaluator.HandRank.FLUSH));
+    }
+
+    @Test
+    void formatFullHouse() {
+        assertEquals("Full House", GameTableView.formatHandRank(HandEvaluator.HandRank.FULL_HOUSE));
+    }
+
+    @Test
+    void formatFourOfAKind() {
+        assertEquals("Four Of A Kind", GameTableView.formatHandRank(HandEvaluator.HandRank.FOUR_OF_A_KIND));
+    }
+
+    @Test
+    void formatStraightFlush() {
+        assertEquals("Straight Flush", GameTableView.formatHandRank(HandEvaluator.HandRank.STRAIGHT_FLUSH));
+    }
+
+    @Test
+    void formatRoyalFlush() {
+        assertEquals("Royal Flush", GameTableView.formatHandRank(HandEvaluator.HandRank.ROYAL_FLUSH));
+    }
+}


### PR DESCRIPTION
## Description

Add property-based tests for the clockwise dealer rotation fix from #17.

## Changes

- `ClockwiseDealerRotationPropertyTest` — verifies dealer advances clockwise for 2–9 players, full cycle rotation
- `ClockwiseDealerPreservationPropertyTest` — verifies blind posting positions, heads-up blind rules, elimination dealer index validity, and reset state restoration

## Testing done

- [x] Unit tests — all new property tests pass
- [x] No new warnings

## Checklist

- [x] Tests added / updated
- [x] No new warnings
- [x] Self-reviewed