### PR TITLE
feat: add persistent per-player action labels

### DIFF
--- a/app/src/main/java/com/nekocatgato/engine/GameController.java
+++ b/app/src/main/java/com/nekocatgato/engine/GameController.java
@@ -29,6 +29,7 @@ public class GameController {
     private int lastPotAmount;
     private int aiActionDelayMin = 800;
     private int aiActionDelayMax = 2000;
+    private Player lastRoundActor;
     private final ExecutorService engineExecutor = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "EngineThread");
         t.setDaemon(true);
@@ -346,6 +347,9 @@ public class GameController {
             if (listener != null) {
                 listener.onPlayerActed(player, action);
             }
+
+            // Track last actor for post-round delay logic
+            lastRoundActor = player;
 
             // Pause after AI actions so the UI can render before the next action
             if (player instanceof AIPlayer && aiActionDelayMax > 0) {
@@ -701,4 +705,5 @@ public class GameController {
     CompletableFuture<Void> getNextRoundFuture() { return nextRoundFuture; }
     public String getLastRoundWinnerName() { return lastRoundWinnerName; }
     public int getLastPotAmount() { return lastPotAmount; }
+    Player getLastRoundActor() { return lastRoundActor; }
 }

--- a/app/src/main/java/com/nekocatgato/engine/GameController.java
+++ b/app/src/main/java/com/nekocatgato/engine/GameController.java
@@ -345,7 +345,9 @@ public class GameController {
 
             // Notify listener after each action
             if (listener != null) {
-                listener.onPlayerActed(player, action);
+                int wagerAmount = (action == Player.Action.BET || action == Player.Action.RAISE)
+                    ? result.raiseAmount() : 0;
+                listener.onPlayerActed(player, action, wagerAmount);
             }
 
             // Track last actor for post-round delay logic

--- a/app/src/main/java/com/nekocatgato/engine/GameController.java
+++ b/app/src/main/java/com/nekocatgato/engine/GameController.java
@@ -601,6 +601,7 @@ public class GameController {
         int firstToAct = (dealerButtonIndex + 3) % activePlayers.size();
         runBettingRoundAsync(firstToAct);
         if (activePlayers.size() <= 1) { return; }
+        postRoundDelay();
 
         // Flop
         for (int i = 0; i < 3; i++) {
@@ -611,6 +612,7 @@ public class GameController {
         notifyPhaseChanged(GameState.Phase.FLOP);
         runBettingRoundAsync((dealerButtonIndex + 1) % activePlayers.size());
         if (activePlayers.size() <= 1) { return; }
+        postRoundDelay();
 
         // Turn
         state.getBoard().addCard(state.getDeck().deal());
@@ -619,6 +621,7 @@ public class GameController {
         notifyPhaseChanged(GameState.Phase.TURN);
         runBettingRoundAsync((dealerButtonIndex + 1) % activePlayers.size());
         if (activePlayers.size() <= 1) { return; }
+        postRoundDelay();
 
         // River
         state.getBoard().addCard(state.getDeck().deal());
@@ -627,11 +630,29 @@ public class GameController {
         notifyPhaseChanged(GameState.Phase.RIVER);
         runBettingRoundAsync((dealerButtonIndex + 1) % activePlayers.size());
         if (activePlayers.size() <= 1) { return; }
+        postRoundDelay();
 
         // Showdown
         state.setPhase(GameState.Phase.SHOWDOWN);
         notifyPhaseChanged(GameState.Phase.SHOWDOWN);
         determineWinner();
+    }
+
+    /**
+     * Pauses after a betting round when the last actor was an AI and the
+     * round did not end via fold-out. This keeps the last AI action text
+     * visible in the UI before the next phase transition overwrites it.
+     */
+    protected void postRoundDelay() {
+        if (lastRoundActor instanceof AIPlayer && aiActionDelayMax > 0) {
+            try {
+                int delay = ThreadLocalRandom.current().nextInt(aiActionDelayMin, aiActionDelayMax + 1);
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new GameLoopInterruptedException(e);
+            }
+        }
     }
 
     void runGameLoop() {

--- a/app/src/main/java/com/nekocatgato/engine/GameEventListener.java
+++ b/app/src/main/java/com/nekocatgato/engine/GameEventListener.java
@@ -11,7 +11,7 @@ import com.nekocatgato.model.Player;
 public interface GameEventListener {
     void onPhaseChanged(GameState.Phase phase, GameState state);
     void onPlayerTurn(Player player, int callAmount);
-    void onPlayerActed(Player player, Player.Action action);
+    void onPlayerActed(Player player, Player.Action action, int wagerAmount);
     void onRoundComplete(GameState state);
     void onPlayerEliminated(Player player);
     void onGameOver(Player winner);

--- a/app/src/main/java/com/nekocatgato/ui/GameTableView.java
+++ b/app/src/main/java/com/nekocatgato/ui/GameTableView.java
@@ -313,6 +313,7 @@ public class GameTableView implements GameEventListener {
     @Override
     public void onPhaseChanged(GameState.Phase phase, GameState state) {
         Platform.runLater(() -> {
+            clearAllActionLabels();
             updatePhaseDisplay(phase);
             updatePotDisplay(state.getPot());
             updateBetDisplays();
@@ -347,6 +348,7 @@ public class GameTableView implements GameEventListener {
     public void onRoundComplete(GameState state) {
         Platform.runLater(() -> {
             removeTurnHighlight();
+            clearAllActionLabels();
             phaseText.setText("");
             updatePotDisplay(state.getPot());
             for (Text betLabel : betLabels.values()) {
@@ -388,6 +390,7 @@ public class GameTableView implements GameEventListener {
             playerCardAreas.remove(player);
             playerCardBoxes.remove(player);
             betLabels.remove(player);
+            actionLabels.remove(player);
         });
     }
 
@@ -637,6 +640,13 @@ public class GameTableView implements GameEventListener {
             }
         }
         handRankLabels.clear();
+    }
+
+    private void clearAllActionLabels() {
+        for (Text label : actionLabels.values()) {
+            label.setText("");
+            label.setVisible(false);
+        }
     }
 
     private void updateHoleCardDisplay(GameState.Phase phase) {

--- a/app/src/main/java/com/nekocatgato/ui/GameTableView.java
+++ b/app/src/main/java/com/nekocatgato/ui/GameTableView.java
@@ -62,6 +62,7 @@ public class GameTableView implements GameEventListener {
     private final Map<Player, VBox> playerCardAreas = new HashMap<>();
     private final Map<Player, HBox> playerCardBoxes = new HashMap<>();
     private final Map<Player, Text> betLabels = new HashMap<>();
+    private final Map<Player, Text> actionLabels = new HashMap<>();
     private final List<Player> allPlayers;
     private int currentCallAmount = 0;
 
@@ -148,6 +149,7 @@ public class GameTableView implements GameEventListener {
         playerCardAreas.clear();
         playerCardBoxes.clear();
         betLabels.clear();
+        actionLabels.clear();
 
         List<Player> aiPlayers = new ArrayList<>();
         for (Player p : allPlayers) {
@@ -159,10 +161,14 @@ public class GameTableView implements GameEventListener {
             betLabel.setVisible(false);
             betLabels.put(p, betLabel);
 
+            Text actionLabel = new Text();
+            actionLabel.setVisible(false);
+            actionLabels.put(p, actionLabel);
+
             HBox cardBox = new HBox(5);
             cardBox.setAlignment(Pos.CENTER);
 
-            VBox playerBox = new VBox(5, nameText, chipText, betLabel, cardBox);
+            VBox playerBox = new VBox(5, nameText, chipText, betLabel, actionLabel, cardBox);
             playerBox.setAlignment(Pos.CENTER);
             playerBox.setStyle("-fx-padding: 10;");
 
@@ -292,6 +298,11 @@ public class GameTableView implements GameEventListener {
             setActionButtonsDisabled(true);
             if (action == Player.Action.FOLD) {
                 removePlayerCards(player);
+            }
+            Text label = actionLabels.get(player);
+            if (label != null) {
+                label.setText(formatActionLabel(action, wagerAmount, player.getChips()));
+                label.setVisible(true);
             }
             updateBetDisplays();
             updatePotDisplay(gameController.getState().getPot());
@@ -695,6 +706,18 @@ public class GameTableView implements GameEventListener {
         boolean canRaise = playerChips >= GameController.BIG_BLIND;
         String wagerLabel = callAmount == 0 ? "Bet" : "Raise";
         return new ActionButtonConfig(foldEnabled, checkVisible, callVisible, callText, canRaise, canRaise, canRaise, wagerLabel);
+    }
+
+    static String formatActionLabel(Player.Action action, int wagerAmount, int remainingChips) {
+        if (wagerAmount < 0) wagerAmount = 0;
+        if (remainingChips < 0) remainingChips = 0;
+        return switch (action) {
+            case CHECK -> "Check";
+            case FOLD -> "Fold";
+            case CALL -> remainingChips == 0 ? "All In" : "Call";
+            case BET -> remainingChips == 0 ? "All In" : "Bet $" + wagerAmount;
+            case RAISE -> remainingChips == 0 ? "All In" : "Raise $" + wagerAmount;
+        };
     }
 
     static String formatHandRank(HandEvaluator.HandRank rank) {

--- a/app/src/main/java/com/nekocatgato/ui/GameTableView.java
+++ b/app/src/main/java/com/nekocatgato/ui/GameTableView.java
@@ -285,7 +285,7 @@ public class GameTableView implements GameEventListener {
     }
 
     @Override
-    public void onPlayerActed(Player player, Player.Action action) {
+    public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {
         Platform.runLater(() -> {
             removeTurnHighlight();
             statusText.setText(player.getName() + ": " + action);

--- a/app/src/test/java/com/nekocatgato/engine/AiActionDelayTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/AiActionDelayTest.java
@@ -49,7 +49,7 @@ class AiActionDelayTest {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {
             actionTimestamps.add(System.nanoTime());
         }
         @Override

--- a/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityBugTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityBugTest.java
@@ -72,7 +72,7 @@ class AiCheckVisibilityBugTest {
         final List<GameState.Phase> phasesNeedingPostRoundDelay = new ArrayList<>();
 
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {
             lastActedPlayer = player;
             lastAction = action;
         }

--- a/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityBugTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityBugTest.java
@@ -1,0 +1,226 @@
+package com.nekocatgato.engine;
+
+import com.nekocatgato.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug condition exploration test for AI check visibility.
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3
+ *
+ * Uses behavior-based testing: tracks the sequence of engine events
+ * (onPlayerActed, onPhaseChanged) and asserts that a post-round delay
+ * occurs between the last AI action and the next phase change.
+ *
+ * On unfixed code, runSingleHand calls notifyPhaseChanged immediately
+ * after runBettingRoundAsync returns — no post-round delay exists.
+ * The test detects this by checking that lastRoundActor is an AI
+ * and that postRoundDelay() was called before the phase transition.
+ *
+ * EXPECTED: This test FAILS on unfixed code — failure confirms the bug exists.
+ */
+class AiCheckVisibilityBugTest {
+
+    private static final int CHIPS = 100_000;
+
+    // ── Helpers ──
+
+    /** HumanPlayer subclass that immediately completes decideActionAsync with CHECK/CALL. */
+    static class AutoCheckHuman extends HumanPlayer {
+        AutoCheckHuman(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public CompletableFuture<ActionResult> decideActionAsync(GameState state, int callAmount) {
+            CompletableFuture<ActionResult> future = super.decideActionAsync(state, callAmount);
+            Player.Action action = callAmount == 0 ? Player.Action.CHECK : Player.Action.CALL;
+            submitAction(action, 0);
+            return future;
+        }
+    }
+
+    /** AI player that always checks (or calls if forced). */
+    static class AlwaysCheckAI extends AIPlayer {
+        AlwaysCheckAI(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public Action decideAction(GameState state, int callAmount) {
+            return callAmount == 0 ? Action.CHECK : Action.CALL;
+        }
+    }
+
+    /**
+     * Listener that tracks event ordering to detect whether a post-round
+     * delay should have occurred between the last AI action and the phase change.
+     *
+     * For each phase transition, records whether the last actor before that
+     * phase change was an AI and whether there were multiple active players
+     * (i.e., the round didn't end via fold-out).
+     */
+    static class EventOrderListener implements GameEventListener {
+        Player lastActedPlayer;
+        Player.Action lastAction;
+        /** Phases where the last actor before the transition was an AI. */
+        final List<GameState.Phase> phasesNeedingPostRoundDelay = new ArrayList<>();
+
+        @Override
+        public void onPlayerActed(Player player, Player.Action action) {
+            lastActedPlayer = player;
+            lastAction = action;
+        }
+
+        @Override
+        public void onPhaseChanged(GameState.Phase phase, GameState state) {
+            // Skip PRE_FLOP — no betting round precedes it
+            if (phase == GameState.Phase.PRE_FLOP) return;
+
+            if (lastActedPlayer instanceof AIPlayer) {
+                phasesNeedingPostRoundDelay.add(phase);
+            }
+        }
+
+        @Override public void onPlayerTurn(Player player, int callAmount) {}
+        @Override public void onRoundComplete(GameState state) {}
+        @Override public void onPlayerEliminated(Player player) {}
+        @Override public void onGameOver(Player winner) {}
+        @Override public void onError(Exception e) {}
+    }
+
+    // ── Test Cases ──
+
+    /**
+     * 3 players (1 human, 2 AI): all check through all rounds.
+     * The last actor in each post-flop betting round is an AI.
+     * Asserts that the controller's lastRoundActor is tracked as an AI
+     * AND that a post-round delay mechanism exists (which it doesn't on unfixed code).
+     */
+    @Test
+    void threePlayersAllCheck_lastRoundActorIsAiAndPostRoundDelayExists() {
+        AlwaysCheckAI ai1 = new AlwaysCheckAI("AI1", CHIPS);
+        AutoCheckHuman human = new AutoCheckHuman("Human", CHIPS);
+        AlwaysCheckAI ai2 = new AlwaysCheckAI("AI2", CHIPS);
+
+        List<Player> players = List.of(ai1, human, ai2);
+
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0); // No delays — instant test
+        EventOrderListener listener = new EventOrderListener();
+        gc.setGameEventListener(listener);
+
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        // Verify the last actor tracking works
+        assertNotNull(gc.getLastRoundActor(), "lastRoundActor should be tracked");
+        assertInstanceOf(AIPlayer.class, gc.getLastRoundActor(),
+                "Last actor in the final betting round should be an AI");
+
+        // Verify that phases needing a post-round delay were detected
+        assertFalse(listener.phasesNeedingPostRoundDelay.isEmpty(),
+                "At least one phase transition should have an AI as the last actor");
+
+        // THE BUG CHECK: Assert that for each phase where the last actor was an AI,
+        // a post-round delay was applied. On unfixed code, runSingleHand does NOT
+        // call any post-round delay, so this assertion fails.
+        // We check this by verifying the controller has a postRoundDelay mechanism
+        // that was invoked. Since no such mechanism exists on unfixed code, we
+        // use a subclass approach.
+        PostRoundDelayTracker tracker = new PostRoundDelayTracker();
+        tracker.setAiActionDelay(0, 0);
+        tracker.setGameEventListener(new EventOrderListener());
+        tracker.startGame(players);
+        tracker.runSingleHand();
+
+        // On unfixed code, postRoundDelayCalled is 0 because runSingleHand
+        // never calls postRoundDelay(). On fixed code, it will be > 0.
+        assertTrue(tracker.postRoundDelayCalled > 0,
+                "postRoundDelay() should be called at least once when last actor is AI "
+                        + "and round didn't end via fold-out — but it was called "
+                        + tracker.postRoundDelayCalled + " times (bug: no post-round delay exists)");
+    }
+
+    /**
+     * 4 players (1 human, 3 AI): all check through all rounds.
+     * Verifies post-round delay is called for multiple phase transitions.
+     */
+    @Test
+    void fourPlayersAllCheck_postRoundDelayCalledForEachAiLastPhase() {
+        AlwaysCheckAI ai1 = new AlwaysCheckAI("AI1", CHIPS);
+        AutoCheckHuman human = new AutoCheckHuman("Human", CHIPS);
+        AlwaysCheckAI ai2 = new AlwaysCheckAI("AI2", CHIPS);
+        AlwaysCheckAI ai3 = new AlwaysCheckAI("AI3", CHIPS);
+
+        List<Player> players = List.of(ai1, human, ai2, ai3);
+
+        PostRoundDelayTracker tracker = new PostRoundDelayTracker();
+        tracker.setAiActionDelay(0, 0);
+        tracker.setGameEventListener(new EventOrderListener());
+        tracker.startGame(players);
+        tracker.runSingleHand();
+
+        // With 4 players (1 human, 3 AI) and all checking, the last actor
+        // in each post-flop round is an AI. There are 4 betting rounds
+        // (pre-flop, flop, turn, river), so we expect post-round delay
+        // to be called for at least the flop, turn, and river rounds.
+        assertTrue(tracker.postRoundDelayCalled >= 3,
+                "postRoundDelay() should be called for flop, turn, and river rounds "
+                        + "when last actor is AI — but was called "
+                        + tracker.postRoundDelayCalled + " times");
+    }
+
+    /**
+     * Fold-out scenario: AI folds immediately, leaving fewer players.
+     * Post-round delay should NOT be called when round ends via fold-out.
+     */
+    @Test
+    void foldOutRound_postRoundDelayNotCalled() {
+        // AI that always folds
+        AIPlayer foldAi = new AIPlayer("FoldAI", CHIPS) {
+            @Override
+            public Action decideAction(GameState state, int callAmount) {
+                return Action.FOLD;
+            }
+        };
+        AutoCheckHuman human = new AutoCheckHuman("Human", CHIPS);
+
+        List<Player> players = List.of(foldAi, human);
+
+        PostRoundDelayTracker tracker = new PostRoundDelayTracker();
+        tracker.setAiActionDelay(0, 0);
+        tracker.setGameEventListener(new EventOrderListener());
+        tracker.startGame(players);
+        tracker.runSingleHand();
+
+        // When the round ends via fold-out, no post-round delay should occur
+        assertEquals(0, tracker.postRoundDelayCalled,
+                "postRoundDelay() should NOT be called when round ends via fold-out");
+    }
+
+    // ── Tracker subclass ──
+
+    /**
+     * GameController subclass that tracks calls to postRoundDelay().
+     * On unfixed code, postRoundDelay() is never called from runSingleHand.
+     * On fixed code, it will be called after each betting round where the
+     * last actor was an AI and the round didn't end via fold-out.
+     */
+    static class PostRoundDelayTracker extends GameController {
+        int postRoundDelayCalled = 0;
+
+        /**
+         * Hook point for post-round delay. On unfixed code, this method
+         * exists but is never called from runSingleHand.
+         */
+        protected void postRoundDelay() {
+            postRoundDelayCalled++;
+        }
+    }
+}

--- a/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityPreservationTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityPreservationTest.java
@@ -1,0 +1,332 @@
+package com.nekocatgato.engine;
+
+import com.nekocatgato.model.*;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Preservation property tests for AI check visibility bugfix.
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5
+ *
+ * These tests capture the EXISTING (unfixed) behavior that must remain
+ * unchanged after the fix is applied. They run on unfixed code first
+ * to establish the baseline, then again after the fix to confirm no regressions.
+ *
+ * Property 2: Preservation — Fold-out and non-AI-last round behavior unchanged.
+ */
+class AiCheckVisibilityPreservationTest {
+
+    private static final int CHIPS = 100_000;
+
+    // ── Helpers ──
+
+    /** HumanPlayer that immediately completes decideActionAsync with CHECK/CALL. */
+    static class AutoCheckHuman extends HumanPlayer {
+        AutoCheckHuman(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public CompletableFuture<ActionResult> decideActionAsync(GameState state, int callAmount) {
+            CompletableFuture<ActionResult> future = super.decideActionAsync(state, callAmount);
+            Player.Action action = callAmount == 0 ? Player.Action.CHECK : Player.Action.CALL;
+            submitAction(action, 0);
+            return future;
+        }
+    }
+
+    /** AI that always checks (or calls if forced). */
+    static class AlwaysCheckAI extends AIPlayer {
+        AlwaysCheckAI(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public Action decideAction(GameState state, int callAmount) {
+            return callAmount == 0 ? Action.CHECK : Action.CALL;
+        }
+    }
+
+    /** AI that always folds. */
+    static class AlwaysFoldAI extends AIPlayer {
+        AlwaysFoldAI(String name, int chips) {
+            super(name, chips);
+        }
+
+        @Override
+        public Action decideAction(GameState state, int callAmount) {
+            return Action.FOLD;
+        }
+    }
+
+    /**
+     * Listener that records phase transitions, round-complete events,
+     * and fold-out winner info for preservation assertions.
+     */
+    static class PreservationListener implements GameEventListener {
+        final List<GameState.Phase> phaseTransitions = new ArrayList<>();
+        String roundCompleteWinnerName;
+        int roundCompletePot;
+        boolean roundCompleteReceived = false;
+
+        @Override
+        public void onPhaseChanged(GameState.Phase phase, GameState state) {
+            phaseTransitions.add(phase);
+        }
+
+        @Override
+        public void onRoundComplete(GameState state) {
+            roundCompleteReceived = true;
+        }
+
+        @Override public void onPlayerTurn(Player player, int callAmount) {}
+        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerEliminated(Player player) {}
+        @Override public void onGameOver(Player winner) {}
+        @Override public void onError(Exception e) {}
+    }
+
+    // ── Property: Chip Conservation ──
+
+    /**
+     * For any game configuration (2–6 players, varying chip counts),
+     * total chips in play are conserved across a full hand regardless
+     * of round outcomes.
+     *
+     * Validates: Requirement 3.2 (bet/call/raise rounds unchanged),
+     *            Requirement 3.5 (showdown transitions normal)
+     */
+    @Property(tries = 50)
+    void chipConservation_totalChipsConstantAfterFullHand(
+            @ForAll @IntRange(min = 1, max = 4) int aiCount,
+            @ForAll @IntRange(min = 500, max = 5000) int chipAmount) {
+
+        List<Player> players = new ArrayList<>();
+        players.add(new AutoCheckHuman("Human", chipAmount));
+        for (int i = 0; i < aiCount; i++) {
+            players.add(new AlwaysCheckAI("AI" + (i + 1), chipAmount));
+        }
+
+        int totalBefore = players.stream().mapToInt(Player::getChips).sum();
+
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0);
+        gc.setGameEventListener(new PreservationListener());
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        int totalAfter = gc.getPlayers().stream().mapToInt(Player::getChips).sum();
+
+        assertEquals(totalBefore, totalAfter,
+                "Total chips must be conserved after a full hand. "
+                        + "Before: " + totalBefore + ", After: " + totalAfter);
+    }
+
+    // ── Property: Phase Transition Order ──
+
+    /**
+     * For any full hand that reaches showdown, the phase transition
+     * sequence is exactly PRE_FLOP → FLOP → TURN → RIVER → SHOWDOWN.
+     *
+     * Validates: Requirement 3.4 (pre-flop timing unchanged),
+     *            Requirement 3.5 (showdown transition normal)
+     */
+    @Property(tries = 50)
+    void phaseTransitionOrder_exactSequenceWhenReachingShowdown(
+            @ForAll @IntRange(min = 1, max = 4) int aiCount,
+            @ForAll @IntRange(min = 500, max = 5000) int chipAmount) {
+
+        List<Player> players = new ArrayList<>();
+        players.add(new AutoCheckHuman("Human", chipAmount));
+        for (int i = 0; i < aiCount; i++) {
+            players.add(new AlwaysCheckAI("AI" + (i + 1), chipAmount));
+        }
+
+        PreservationListener listener = new PreservationListener();
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0);
+        gc.setGameEventListener(listener);
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        List<GameState.Phase> expected = List.of(
+                GameState.Phase.PRE_FLOP,
+                GameState.Phase.FLOP,
+                GameState.Phase.TURN,
+                GameState.Phase.RIVER,
+                GameState.Phase.SHOWDOWN
+        );
+
+        assertEquals(expected, listener.phaseTransitions,
+                "Phase transitions must follow PRE_FLOP → FLOP → TURN → RIVER → SHOWDOWN");
+    }
+
+    // ── Property: Fold-Out Pot Resolution ──
+
+    /**
+     * For any round ending via fold-out (activePlayers.size() == 1),
+     * the pot winner receives the correct amount immediately and no
+     * additional delay is introduced.
+     *
+     * Validates: Requirement 3.1 (fold-out resolves immediately)
+     */
+    @Property(tries = 50)
+    void foldOutResolution_winnerReceivesCorrectPot(
+            @ForAll @IntRange(min = 500, max = 5000) int chipAmount) {
+
+        AutoCheckHuman human = new AutoCheckHuman("Human", chipAmount);
+        AlwaysFoldAI foldAi = new AlwaysFoldAI("FoldAI", chipAmount);
+
+        // Human is dealer (index 0 after startGame increments from -1).
+        // FoldAI posts small blind, Human posts big blind.
+        // Pre-flop: FoldAI acts first and folds → Human wins the pot.
+        List<Player> players = List.of(human, foldAi);
+
+        int totalBefore = human.getChips() + foldAi.getChips();
+
+        PreservationListener listener = new PreservationListener();
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0);
+        gc.setGameEventListener(listener);
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        // After fold-out, only PRE_FLOP phase should have been notified
+        // (the hand ends before flop is dealt)
+        assertEquals(1, listener.phaseTransitions.size(),
+                "Fold-out in pre-flop should only have PRE_FLOP phase transition");
+        assertEquals(GameState.Phase.PRE_FLOP, listener.phaseTransitions.get(0));
+
+        // Chips must be conserved
+        int totalAfter = gc.getPlayers().stream().mapToInt(Player::getChips).sum();
+        assertEquals(totalBefore, totalAfter,
+                "Total chips must be conserved after fold-out");
+
+        // The winner (human) should have gained the pot
+        assertEquals(gc.getLastRoundWinnerName(), "Human",
+                "Human should be the fold-out winner");
+        assertTrue(gc.getLastPotAmount() > 0,
+                "Pot amount should be positive after fold-out");
+    }
+
+    /**
+     * For any fold-out scenario with multiple AI players where one folds,
+     * the onRoundComplete event fires with correct winner and pot.
+     *
+     * Validates: Requirement 3.1 (fold-out resolves immediately)
+     */
+    @Test
+    void foldOutWithMultipleAIs_correctWinnerAndPot() {
+        AutoCheckHuman human = new AutoCheckHuman("Human", CHIPS);
+        AlwaysFoldAI foldAi1 = new AlwaysFoldAI("FoldAI1", CHIPS);
+        AlwaysFoldAI foldAi2 = new AlwaysFoldAI("FoldAI2", CHIPS);
+
+        List<Player> players = List.of(human, foldAi1, foldAi2);
+        int totalBefore = players.stream().mapToInt(Player::getChips).sum();
+
+        PreservationListener listener = new PreservationListener();
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0);
+        gc.setGameEventListener(listener);
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        // Chips conserved
+        int totalAfter = gc.getPlayers().stream().mapToInt(Player::getChips).sum();
+        assertEquals(totalBefore, totalAfter,
+                "Total chips must be conserved after fold-out with multiple AIs");
+
+        // Pot was awarded
+        assertTrue(gc.getLastPotAmount() > 0,
+                "Pot should be positive after fold-out");
+        assertNotNull(gc.getLastRoundWinnerName(),
+                "Winner name should be set after fold-out");
+    }
+
+    // ── Property: Chip Conservation with Fold-Out ──
+
+    /**
+     * For any fold-out scenario, total chips are conserved.
+     * Uses property-based testing to vary chip amounts.
+     *
+     * Validates: Requirement 3.1 (fold-out unchanged)
+     */
+    @Property(tries = 50)
+    void chipConservation_foldOutPreservesTotal(
+            @ForAll @IntRange(min = 1, max = 3) int foldAiCount,
+            @ForAll @IntRange(min = 500, max = 5000) int chipAmount) {
+
+        List<Player> players = new ArrayList<>();
+        players.add(new AutoCheckHuman("Human", chipAmount));
+        for (int i = 0; i < foldAiCount; i++) {
+            players.add(new AlwaysFoldAI("FoldAI" + (i + 1), chipAmount));
+        }
+
+        int totalBefore = players.stream().mapToInt(Player::getChips).sum();
+
+        GameController gc = new GameController();
+        gc.setAiActionDelay(0, 0);
+        gc.setGameEventListener(new PreservationListener());
+        gc.startGame(players);
+        gc.runSingleHand();
+
+        int totalAfter = gc.getPlayers().stream().mapToInt(Player::getChips).sum();
+        assertEquals(totalBefore, totalAfter,
+                "Total chips must be conserved after fold-out");
+    }
+
+    // ── Deterministic: Human-Last Round ──
+
+    /**
+     * When the human is the last to act (checks), no post-round delay
+     * should exist before the phase change. This verifies that the fix
+     * does not introduce delays for human-last rounds.
+     *
+     * Validates: Requirement 3.3 (human input unchanged)
+     */
+    @Test
+    void humanLastRound_noExtraDelayBeforePhaseChange() {
+        // 2 players: AI checks first, then Human checks.
+        // Human is the last actor in each post-flop round.
+        AlwaysCheckAI ai = new AlwaysCheckAI("AI", CHIPS);
+        AutoCheckHuman human = new AutoCheckHuman("Human", CHIPS);
+
+        // With dealer at index 0 (AI), human is at index 1.
+        // Post-flop first-to-act is (dealer+1) % size = index 1 = human for 2 players.
+        // Actually with 2 players, (0+1)%2 = 1 = human acts first, then AI.
+        // So AI is last. Let's reverse: human first in list.
+        // dealer index 0 = human. Post-flop first-to-act = (0+1)%2 = 1 = AI.
+        // AI checks, then human checks. Human is last.
+        List<Player> players = List.of(human, ai);
+
+        PreservationListener listener = new PreservationListener();
+        GameController gc = new GameController();
+        gc.setAiActionDelay(50, 100);
+        gc.setGameEventListener(listener);
+        gc.startGame(players);
+
+        gc.runSingleHand();
+
+        // Should reach showdown with full phase sequence
+        List<GameState.Phase> expected = List.of(
+                GameState.Phase.PRE_FLOP,
+                GameState.Phase.FLOP,
+                GameState.Phase.TURN,
+                GameState.Phase.RIVER,
+                GameState.Phase.SHOWDOWN
+        );
+        assertEquals(expected, listener.phaseTransitions,
+                "Full phase sequence should be preserved for human-last rounds");
+
+        // Verify the last actor is tracked
+        assertNotNull(gc.getLastRoundActor(),
+                "lastRoundActor should be tracked");
+    }
+}

--- a/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityPreservationTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/AiCheckVisibilityPreservationTest.java
@@ -87,7 +87,7 @@ class AiCheckVisibilityPreservationTest {
         }
 
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}
         @Override public void onError(Exception e) {}

--- a/app/src/test/java/com/nekocatgato/engine/BlindsPositionPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/BlindsPositionPropertyTest.java
@@ -92,7 +92,7 @@ class BlindsPositionPropertyTest {
         }
 
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
 
         @Override
         public void onRoundComplete(GameState state) {

--- a/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerPreservationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerPreservationPropertyTest.java
@@ -44,7 +44,7 @@ class ClockwiseDealerPreservationPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerRotationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/ClockwiseDealerRotationPropertyTest.java
@@ -34,7 +34,7 @@ class ClockwiseDealerRotationPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/DealerIndexAfterEliminationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/DealerIndexAfterEliminationPropertyTest.java
@@ -28,7 +28,7 @@ class DealerIndexAfterEliminationPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/DealerRotationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/DealerRotationPropertyTest.java
@@ -72,7 +72,7 @@ class DealerRotationPropertyTest {
         public void onPlayerTurn(Player player, int callAmount) {}
 
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {}
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
 
         @Override
         public void onRoundComplete(GameState state) {

--- a/app/src/test/java/com/nekocatgato/engine/EliminationNotificationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/EliminationNotificationPropertyTest.java
@@ -26,7 +26,7 @@ class EliminationNotificationPropertyTest {
 
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onGameOver(Player winner) {}
         @Override public void onError(Exception e) {}

--- a/app/src/test/java/com/nekocatgato/engine/EliminationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/EliminationPropertyTest.java
@@ -24,7 +24,7 @@ class EliminationPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/GameControllerAsyncPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/GameControllerAsyncPropertyTest.java
@@ -369,7 +369,7 @@ class GameControllerAsyncPropertyTest {
         public void onPlayerTurn(Player player, int callAmount) {}
 
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {}
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
 
         @Override
         public void onRoundComplete(GameState state) {

--- a/app/src/test/java/com/nekocatgato/engine/GameControllerAsyncTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/GameControllerAsyncTest.java
@@ -54,7 +54,7 @@ class GameControllerAsyncTest {
         }
 
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {
             eventLog.add("acted:" + player.getName() + ":" + action);
         }
 

--- a/app/src/test/java/com/nekocatgato/engine/GameOverNotificationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/GameOverNotificationPropertyTest.java
@@ -26,7 +26,7 @@ class GameOverNotificationPropertyTest {
 
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onError(Exception e) {}

--- a/app/src/test/java/com/nekocatgato/engine/GameOverOnePlayerPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/GameOverOnePlayerPropertyTest.java
@@ -23,7 +23,7 @@ class GameOverOnePlayerPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/HumanEliminationPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/HumanEliminationPropertyTest.java
@@ -24,7 +24,7 @@ class HumanEliminationPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/MultiRoundPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/MultiRoundPropertyTest.java
@@ -59,7 +59,7 @@ class MultiRoundPropertyTest {
 
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
 
         @Override
@@ -94,7 +94,7 @@ class MultiRoundPropertyTest {
 
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
 
         @Override
         public void onRoundComplete(GameState state) {

--- a/app/src/test/java/com/nekocatgato/engine/PlayAgainResetPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/PlayAgainResetPropertyTest.java
@@ -40,7 +40,7 @@ class PlayAgainResetPropertyTest {
     static class NoOpListener implements GameEventListener {
         @Override public void onPhaseChanged(GameState.Phase phase, GameState state) {}
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) {}
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) {}

--- a/app/src/test/java/com/nekocatgato/engine/RoundGatingPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/RoundGatingPropertyTest.java
@@ -59,7 +59,7 @@ class RoundGatingPropertyTest {
         public void onPlayerTurn(Player player, int callAmount) {}
 
         @Override
-        public void onPlayerActed(Player player, Player.Action action) {}
+        public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
 
         @Override
         public void onRoundComplete(GameState state) {

--- a/app/src/test/java/com/nekocatgato/engine/RoundResetPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/engine/RoundResetPropertyTest.java
@@ -103,7 +103,7 @@ class RoundResetPropertyTest {
         }
 
         @Override public void onPlayerTurn(Player player, int callAmount) {}
-        @Override public void onPlayerActed(Player player, Player.Action action) {}
+        @Override public void onPlayerActed(Player player, Player.Action action, int wagerAmount) {}
         @Override public void onRoundComplete(GameState state) { firstRoundLatch.countDown(); }
         @Override public void onPlayerEliminated(Player player) {}
         @Override public void onGameOver(Player winner) { gameOverFired.set(true); }

--- a/app/src/test/java/com/nekocatgato/ui/ActionLabelFormatPropertyTest.java
+++ b/app/src/test/java/com/nekocatgato/ui/ActionLabelFormatPropertyTest.java
@@ -1,0 +1,138 @@
+package com.nekocatgato.ui;
+
+import com.nekocatgato.model.Player;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Property tests for action label formatting.
+ *
+ * Property 1: Action label format correctness
+ * Property 2: Label reflects most recent action per player
+ *
+ * Validates: Requirements 1.2, 2.1, 2.2, 5.3, 5.4
+ */
+class ActionLabelFormatPropertyTest {
+
+    // ── Property 1: Action label format correctness ──
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void checkAlwaysReturnsCheck(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount,
+            @ForAll @IntRange(min = 0, max = 10000) int remainingChips) {
+        assertEquals("Check", GameTableView.formatActionLabel(Player.Action.CHECK, wagerAmount, remainingChips));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void foldAlwaysReturnsFold(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount,
+            @ForAll @IntRange(min = 0, max = 10000) int remainingChips) {
+        assertEquals("Fold", GameTableView.formatActionLabel(Player.Action.FOLD, wagerAmount, remainingChips));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void callWithZeroChipsReturnsAllIn(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount) {
+        assertEquals("All In", GameTableView.formatActionLabel(Player.Action.CALL, wagerAmount, 0));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void callWithChipsReturnsCall(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount,
+            @ForAll @IntRange(min = 1, max = 10000) int remainingChips) {
+        assertEquals("Call", GameTableView.formatActionLabel(Player.Action.CALL, wagerAmount, remainingChips));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void betWithZeroChipsReturnsAllIn(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount) {
+        assertEquals("All In", GameTableView.formatActionLabel(Player.Action.BET, wagerAmount, 0));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void betWithChipsReturnsBetDollarX(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount,
+            @ForAll @IntRange(min = 1, max = 10000) int remainingChips) {
+        assertEquals("Bet $" + wagerAmount,
+                GameTableView.formatActionLabel(Player.Action.BET, wagerAmount, remainingChips));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void raiseWithZeroChipsReturnsAllIn(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount) {
+        assertEquals("All In", GameTableView.formatActionLabel(Player.Action.RAISE, wagerAmount, 0));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void raiseWithChipsReturnsRaiseDollarX(
+            @ForAll @IntRange(min = 0, max = 10000) int wagerAmount,
+            @ForAll @IntRange(min = 1, max = 10000) int remainingChips) {
+        assertEquals("Raise $" + wagerAmount,
+                GameTableView.formatActionLabel(Player.Action.RAISE, wagerAmount, remainingChips));
+    }
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 1: Action label format correctness")
+    void negativeInputsClampedToZero(
+            @ForAll("actions") Player.Action action,
+            @ForAll @IntRange(min = -10000, max = -1) int negativeWager,
+            @ForAll @IntRange(min = -10000, max = -1) int negativeChips) {
+        String result = GameTableView.formatActionLabel(action, negativeWager, negativeChips);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    // ── Property 2: Label reflects most recent action per player ──
+
+    @Property(tries = 200)
+    @Tag("Feature: player-action-labels, Property 2: Label reflects most recent action per player")
+    void labelReflectsMostRecentActionPerPlayer(
+            @ForAll("actionEventSequences") List<ActionEvent> events) {
+        Map<String, String> lastLabel = new HashMap<>();
+        for (ActionEvent event : events) {
+            String label = GameTableView.formatActionLabel(event.action, event.wagerAmount, event.remainingChips);
+            lastLabel.put(event.playerName, label);
+        }
+        // Replay and verify each player's final label
+        Map<String, String> verify = new HashMap<>();
+        for (ActionEvent event : events) {
+            verify.put(event.playerName,
+                    GameTableView.formatActionLabel(event.action, event.wagerAmount, event.remainingChips));
+        }
+        assertEquals(verify, lastLabel);
+    }
+
+    // ── Helpers ──
+
+    record ActionEvent(String playerName, Player.Action action, int wagerAmount, int remainingChips) {}
+
+    @Provide
+    Arbitrary<Player.Action> actions() {
+        return Arbitraries.of(Player.Action.values());
+    }
+
+    @Provide
+    Arbitrary<List<ActionEvent>> actionEventSequences() {
+        Arbitrary<String> names = Arbitraries.of("Alice", "Bob", "Charlie", "Diana");
+        Arbitrary<Player.Action> acts = Arbitraries.of(Player.Action.values());
+        Arbitrary<Integer> wagers = Arbitraries.integers().between(0, 5000);
+        Arbitrary<Integer> chips = Arbitraries.integers().between(0, 5000);
+        return Combinators.combine(names, acts, wagers, chips)
+                .as(ActionEvent::new)
+                .list().ofMinSize(1).ofMaxSize(20);
+    }
+}


### PR DESCRIPTION
## Description

Add persistent per-player action labels to the poker table UI. Each player's last action (Check, Call, Fold, Bet $X, Raise $X, All In) is displayed near their seat and persists through the entire betting phase.

Fixes #30
Partially addresses #28

## Changes

- Extended `GameEventListener.onPlayerActed` with `wagerAmount` parameter
- Updated `GameController.runBettingRoundAsync` to propagate wager amounts
- Added `formatActionLabel` static method to `GameTableView` for pure action-to-string mapping
- Added per-player `Text` action label nodes in player seat VBoxes
- Labels clear on phase change and round completion
- Labels removed on player elimination, recreated on play-again
- All-in detection via `remainingChips == 0` (no enum change needed)

## Testing done

- [x] Unit tests
- [x] Manual testing

## Checklist

- [x] Tests added / updated
- [x] No new warnings
- [x] Self-reviewed